### PR TITLE
GET | /is-auth

### DIFF
--- a/server/controllers/auth.js
+++ b/server/controllers/auth.js
@@ -1,6 +1,7 @@
 const { sign } = require('jsonwebtoken');
 const { compare, hash, genSalt } = require('bcrypt');
 const { loginSchema, registerSchema } = require('../utils/validation');
+const { verify } = require('../utils/verify');
 const {
   getArtistByEmail,
   addArtist,
@@ -118,4 +119,13 @@ exports.registerController = async (req, res, next) => {
 
 exports.logout = (req, res) => {
   res.clearCookie('token').json({ status: 200, message: 'logout success' });
+};
+
+exports.isAuth = async (req, res) => {
+  try {
+    const { id, role } = await verify(req.cookies.token);
+    res.json({ statusCode: 200, data: { id, role } });
+  } catch (err) {
+    res.status(401).json({ statusCode: 401, message: 'Un-Authorized' });
+  }
 };

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,8 +1,9 @@
 const router = require('express').Router();
 const {
-  auth: { registerController, login, logout },
+  auth: { registerController, login, logout, isAuth },
 } = require('../controllers');
 
+router.get('/is-auth', isAuth);
 router.post('/sign-up', registerController);
 
 router.post('/admin', login);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,3 +1,55 @@
-test('Initial test to pass pre-commit', () => {
-  expect(1).toBe(1);
+const request = require('supertest');
+const connection = require('../server/database/connection');
+const dbBuild = require('../server/database/data/build');
+
+const app = require('../server/app');
+
+beforeAll(() => dbBuild());
+
+afterAll(() => connection.end());
+
+describe('test if authorized or not if was customer', () => {
+  test('testing for /is-auth ', (done) => {
+    request(app)
+      .get('/api/v1/is-auth')
+      .set('Cookie', [`token=${process.env.CUSTOMER_TOKEN}`])
+      .expect(200)
+      .end((err, res) => {
+        if (err) return done(err);
+        const {
+          body: { data },
+        } = res;
+        expect(data).toEqual({ id: 1, role: 'customer' });
+        return done();
+      });
+  });
+
+  test('testing for /is-auth if was artist ', (done) => {
+    request(app)
+      .get('/api/v1/is-auth')
+      .set('Cookie', [`token=${process.env.ARTIST_TOKEN}`])
+      .expect(200)
+      .end((err, res) => {
+        if (err) return done(err);
+        const {
+          body: { data },
+        } = res;
+        expect(data).toEqual({ id: 1, role: 'artist' });
+        return done();
+      });
+  });
+
+  test("testing for /is-auth if wasn't authorized ", (done) => {
+    request(app)
+      .get('/api/v1/is-auth')
+      .expect(401)
+      .end((err, res) => {
+        if (err) return done(err);
+        const {
+          body: { message },
+        } = res;
+        expect(message).toBe('Un-Authorized');
+        return done();
+      });
+  });
 });


### PR DESCRIPTION
- I handled `/is-auth` route with `GET` method with a controller function which whill :

1. Verify `req.cookies.token`, if user has signed in a response with 
```js
{ statusCode: 200, data: { id, role } }
``` 
will be sent.

2. If user didn't sign in a response with 
```js
res.status(401).json({ statusCode: 401, message: 'Un-Authorized' })
``` 
will be sent.

- I made a three tests which they are covering the three possible respons.